### PR TITLE
implicit declaration of function 'main'

### DIFF
--- a/src/cr_startup_lpc8xx.c
+++ b/src/cr_startup_lpc8xx.c
@@ -54,6 +54,8 @@ extern "C" {
 extern "C" {
 #endif
 
+int main(void);
+
 //*****************************************************************************
 //
 // Forward declaration of the default handlers. These are aliased.

--- a/src/gcc_startup_lpc8xx.c
+++ b/src/gcc_startup_lpc8xx.c
@@ -28,6 +28,8 @@ static unsigned int StackMem[STACKSIZE];
 #define WEAK __attribute__ ((weak))
 #define ALIAS(f) __attribute__ ((weak, alias (#f)))
 
+int main(void);
+
 //*****************************************************************************
 //
 // Forward declaration of the default handlers. These are aliased.


### PR DESCRIPTION
Prevent warning 
```
gcc_startup_lpc8xx.c: In function 'ResetISR':
gcc_startup_lpc8xx.c:177:5: warning: implicit declaration of function 'main' [-Wimplicit-function-declaration]
  177 |     main();
      |     ^~~~
```